### PR TITLE
Add CI pipeline for deploying to Azure

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,27 @@
+name: Deploy to Azure
+on:
+  push:
+    branches:
+      - 'main'
+
+jobs:
+  deploy:
+    name: Deployment
+    runs-on: ubuntu-20.04
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Set the app name
+      run: echo "AZURE_APP_NAME=${REPO_NAME,,}" >>${GITHUB_ENV}
+      env:
+        REPO_NAME: '${{ github.event.repository.name }}'
+ 
+    - name: Log in to Azure CLI
+      uses: azure/login@v1
+      with:
+        creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+    - name: Deploy to Azure
+      run: |
+        az containerapp up -n $AZURE_APP_NAME --ingress external --target-port 3000 --source .


### PR DESCRIPTION
This pull request adds a CI pipeline for deploying to Azure. The pipeline is triggered on pushes to the main branch and includes steps for checking out the code, setting the app name, logging in to Azure CLI, and deploying to Azure using the `az containerapp up` command.